### PR TITLE
Require explicit OPENAI_API_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ La aplicación se ha probado con Python 3.10 como versión mínima recomendada.
     source venv/bin/activate  # En Windows: venv\Scripts\activate
     pip install -r requirements.txt
     ```
-3.  (Recomendado) Configura tu clave de API de OpenAI como una variable de entorno llamada `OPENAI_API_KEY`.
+3.  Configura tu clave de API de OpenAI como una variable de entorno llamada `OPENAI_API_KEY` (obligatorio). La aplicación no se ejecutará si no la proporcionas.
     *   En Windows (PowerShell): `$env:OPENAI_API_KEY="tu_clave_aqui"`
     *   En Linux/macOS: `export OPENAI_API_KEY="tu_clave_aqui"`
     *   Asegúrate de reemplazar `"tu_clave_aqui"` con tu clave real.

--- a/classroom_app.py
+++ b/classroom_app.py
@@ -12,28 +12,10 @@ import student_db
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 
 if not OPENAI_API_KEY:
-    # Si no se encuentra en variable de entorno, usa la clave proporcionada
-    # SOLO PARA DESARROLLO LOCAL Y CON CONOCIMIENTO DEL RIESGO.
-    # REEMPLAZA ESTO ANTES DE COMPARTIR O SUBIR A GITHUB.
-    PROVIDED_API_KEY = "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" # Clave proporcionada por el USER
-    print("--------------------------------------------------------------------------------")
-    print("ADVERTENCIA DE SEGURIDAD MUY IMPORTANTE:")
-    print("Estás utilizando una clave API de OpenAI directamente en el código.")
-    print("Esto es EXTREMADAMENTE INSEGURO si este código se comparte o sube a GitHub.")
-    print("La clave podría ser robada y usada maliciosamente, generando costos para ti.")
-    print("POR FAVOR, configura la variable de entorno OPENAI_API_KEY y elimina la clave del código.")
-    print("Ejemplo en PowerShell: $env:OPENAI_API_KEY=\"tu_clave_real_aqui\"")
-    print("Ejemplo en bash/zsh: export OPENAI_API_KEY=\"tu_clave_real_aqui\"")
-    print("El script continuará usando la clave hardcodeada por ahora, bajo tu responsabilidad.")
-    print("--------------------------------------------------------------------------------\n")
-    OPENAI_API_KEY = PROVIDED_API_KEY
-else:
-    print("Clave API de OpenAI cargada desde la variable de entorno OPENAI_API_KEY.")
-
-if not OPENAI_API_KEY:
-    print("Error fatal: No se pudo obtener la clave API de OpenAI.")
-    print("Configura la variable de entorno OPENAI_API_KEY o asegúrate de que la clave esté disponible.")
-    exit()
+    print("Error: La variable de entorno OPENAI_API_KEY es obligatoria.")
+    print("Configura la variable de entorno y vuelve a ejecutar la aplicacion.")
+    exit(1)
+print("Clave API de OpenAI cargada desde la variable de entorno OPENAI_API_KEY.")
 
 try:
     client = openai.OpenAI(api_key=OPENAI_API_KEY)


### PR DESCRIPTION
## Summary
- remove provided API key fallback from `classroom_app.py`
- exit if `OPENAI_API_KEY` is missing
- clarify README that the env variable is required

## Testing
- `python -m py_compile classroom_app.py`

------
https://chatgpt.com/codex/tasks/task_e_684e4e81dfe8832b82ff523e3fae2c2e